### PR TITLE
Spotify Service: Set up refresh token support

### DIFF
--- a/src/App/views/AuthView/index.tsx
+++ b/src/App/views/AuthView/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import ViewOptions, * as Views from 'App/views';
 import { SelectableList, SelectableListOption } from 'components';
@@ -7,11 +7,21 @@ import { useSpotifyService } from 'services/spotify';
 import { useWindowService } from 'services/window';
 import { isDev } from 'utils';
 
-const AuthView = () => {
-  const { loggedIn } = useSpotifyService();
-  const { resetWindowStack } = useWindowService();
+const initialOptions: SelectableListOption[] = [
+  {
+    label: "Spotify Signin",
+    value: "hi",
+    link: `http://tannerv.ddns.net:3001/${isDev ? "login_dev" : "login"}`
+  }
+];
 
-  useEffect(() => {
+const AuthView = () => {
+  const { resetWindowStack } = useWindowService();
+  const [options] = useState(initialOptions);
+  const [index] = useScrollHandler(ViewOptions.auth.id, options);
+  const { loggedIn } = useSpotifyService();
+
+  const handleCheckLogin = useCallback(() => {
     if (loggedIn) {
       resetWindowStack({
         id: ViewOptions.home.id,
@@ -21,16 +31,9 @@ const AuthView = () => {
     }
   }, [loggedIn, resetWindowStack]);
 
-  const initialOptions: SelectableListOption[] = [
-    {
-      label: "Spotify Signin",
-      value: "hi",
-      link: `http://tannerv.ddns.net:3001/${isDev ? 'login_dev' : 'login'}`
-    }
-  ];
-
-  const [options] = useState(initialOptions);
-  const [index] = useScrollHandler(ViewOptions.auth.id, options);
+  useEffect(() => {
+    handleCheckLogin();
+  }, [handleCheckLogin]);
 
   return <SelectableList options={options} activeIndex={index} />;
 };

--- a/src/components/Controls/Scrubber.tsx
+++ b/src/components/Controls/Scrubber.tsx
@@ -43,9 +43,7 @@ const Scubber = ({ isScrubbing }: Props) => {
   const [maxTime, setMaxTime] = useState(0);
   const { playing, loading } = useAudioService();
   const percent = Math.round((currentTime / maxTime) * 100);
-  const {
-    spotifyState: { player, playerState }
-  } = useSpotifyService();
+  const { player, playerState } = useSpotifyService();
 
   const scrubForward = useCallback(() => {
     if (currentTime === maxTime || !isScrubbing) return;

--- a/src/components/Controls/TrackProgress.tsx
+++ b/src/components/Controls/TrackProgress.tsx
@@ -39,9 +39,7 @@ const TrackProgress = () => {
   const [maxTime, setMaxTime] = useState(0);
   const { playing, loading } = useAudioService();
   const percent = Math.round((currentTime / maxTime) * 100);
-  const {
-    spotifyState: { playerState, player }
-  } = useSpotifyService();
+  const { playerState, player } = useSpotifyService();
 
   const refresh = useCallback(
     async (force?: boolean) => {

--- a/src/components/NowPlaying/index.tsx
+++ b/src/components/NowPlaying/index.tsx
@@ -63,8 +63,7 @@ interface Props {
 }
 
 const NowPlaying = ({ hideArtwork, onHide }: Props) => {
-  const { spotifyState } = useSpotifyService();
-  const { playerState } = spotifyState;
+  const { playerState } = useSpotifyService();
   const [windowHidden, setWindowHidden] = useState(false);
 
   const currentTrack = playerState?.track_window.current_track;

--- a/src/hooks/useSpotifyApi.ts
+++ b/src/hooks/useSpotifyApi.ts
@@ -11,8 +11,7 @@ const useSpotifyApi = <TType>(
   endpoint: string,
   optionsOverride?: RequestInit
 ): SpotifyApiHook<TType> => {
-  const { spotifyState } = useSpotifyService();
-  const { accessToken } = spotifyState;
+  const { accessToken } = useSpotifyService();
 
   const shouldFetch = !!accessToken;
 

--- a/src/hooks/useSpotifyPlayer.ts
+++ b/src/hooks/useSpotifyPlayer.ts
@@ -12,8 +12,7 @@ interface SpotifyPlayerHook {
 const apiUrl = "https://api.spotify.com/v1/me/player";
 
 const useSpotifyPlayer = (): SpotifyPlayerHook => {
-  const { spotifyState } = useSpotifyService();
-  const { accessToken, deviceId, player } = spotifyState;
+  const { accessToken, deviceId, player } = useSpotifyService();
   const { setPlaying } = useAudioService();
 
   const headers = {

--- a/src/hooks/useVolumeHandler.ts
+++ b/src/hooks/useVolumeHandler.ts
@@ -15,9 +15,7 @@ const useVolumeHandler = (): VolumeHandlerHook => {
   const [volume, setVolume] = useState(100);
   const [enabled, setIsEnabled] = useState(true);
   const timeoutIdRef = useRef<any>();
-  const {
-    spotifyState: { player }
-  } = useSpotifyService();
+  const { player } = useSpotifyService();
 
   const handleMount = useCallback(async () => {
     const currentVolume = ((await player?.getVolume()) ?? 0) * 100;

--- a/src/utils/accessToken.ts
+++ b/src/utils/accessToken.ts
@@ -1,0 +1,145 @@
+export type TokenResponse = {
+  accessToken?: string;
+  refreshToken?: string;
+};
+
+/** Determines if an access token has been saved at a prior time,
+ * and if so, attempts to refresh the token. If no prior tokens
+ * have been set, fetch a brand new one and save it to localStorage.
+ */
+export const getTokens = async (): Promise<TokenResponse> => {
+  const { storedAccessToken, storedRefreshToken } = getExistingTokens();
+
+  if (!storedAccessToken || !storedRefreshToken) {
+    return _getNewTokens();
+  }
+
+  if (_shouldRefreshTokens()) {
+    return _getRefreshedTokens(storedRefreshToken);
+  }
+
+  return {
+    accessToken: storedAccessToken,
+    refreshToken: storedRefreshToken
+  };
+};
+
+export const getExistingTokens = () => {
+  const storedAccessToken =
+    localStorage.getItem("spotify_access_token") ?? undefined;
+  const storedRefreshToken =
+    localStorage.getItem("spotify_refresh_token") ?? undefined;
+
+  return {
+    storedAccessToken,
+    storedRefreshToken
+  };
+};
+
+/** Accepts a refresh token and returns a fresh access token.
+ * Valid for 1 hour, at which point the token will expire.
+ */
+const _getRefreshedTokens = async (
+  storedRefreshToken: string
+): Promise<TokenResponse> => {
+  try {
+    const response = await fetch(
+      `http://tannerv.ddns.net:3001/refresh_token?refresh_token=${storedRefreshToken}`,
+      {
+        credentials: "same-origin",
+        mode: "cors"
+      }
+    );
+
+    const { access_token: accessToken } = await response.json();
+
+    console.log("Got refreshed tokens:", { accessToken, storedRefreshToken });
+
+    _saveTokens(accessToken, storedRefreshToken);
+
+    return { accessToken, refreshToken: storedRefreshToken };
+  } catch (error) {
+    console.error("Error fetchinng refresh token:", { error });
+  }
+
+  return {
+    accessToken: undefined,
+    refreshToken: undefined
+  };
+};
+
+/** Accepts a `code` and `state` generated from spotify user authorization,
+ * and attempts to fetch a new access and refresh token.
+ * Valid for 1 hour, at which point the access token will expire.
+ */
+const _getNewTokens = async (): Promise<TokenResponse> => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const code = urlParams.get("code") ?? undefined;
+  const state = urlParams.get("state") ?? undefined;
+
+  if (!code || !state) {
+    throw new Error("Error: Code or State params weren't found.");
+  }
+
+  try {
+    const response = await fetch(
+      `http://tannerv.ddns.net:3001/callback?state=${state}&code=${code}`,
+      {
+        credentials: "same-origin",
+        mode: "cors"
+      }
+    );
+
+    const { accessToken, refreshToken } = await response.json();
+
+    _saveTokens(accessToken, refreshToken);
+
+    return {
+      accessToken,
+      refreshToken
+    };
+  } catch (error) {
+    console.error("error fetching token:", { error });
+  }
+
+  return {
+    accessToken: undefined,
+    refreshToken: undefined
+  };
+};
+
+/** Checks the last time an access token was requested.
+ * If a token has never been requested, return true.
+ * If the last refresh was > 30 minutes ago, return true.
+ */
+const _shouldRefreshTokens = () => {
+  const lastRefreshTimestamp = parseInt(
+    localStorage.getItem("spotify_token_timestamp") ?? ""
+  );
+  const now = Date.now();
+
+  if (!lastRefreshTimestamp) {
+    return true;
+  }
+
+  //Gets the time difference in minutes.
+  const minuteDiff = Math.round((now - lastRefreshTimestamp) / 1000 / 60);
+  console.log(`Last token refresh: ${minuteDiff} minutes ago`);
+
+  return minuteDiff > 30;
+};
+
+const _saveTokens = (accessToken?: string, refreshToken?: string) => {
+  if (!accessToken || !refreshToken) {
+    console.error("Error: Attempting to save undefined tokens:", {
+      accessToken,
+      refreshToken
+    });
+
+    return;
+  }
+
+  localStorage.setItem("spotify_access_token", accessToken);
+  localStorage.setItem("spotify_refresh_token", refreshToken);
+  localStorage.setItem("spotify_token_timestamp", `${Date.now()}`);
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,7 @@
 import { Song } from 'services/audio';
 
+export * from "./accessToken";
+
 export const getUrlFromPath = (path: string) =>
   `https://tannerv.ddns.net/SpotiFree/${encodeURI(path)}`;
 
@@ -25,4 +27,4 @@ export const setDocumentSongTitle = (song?: Song) => {
   document.title = song ? `${song.name} – iPod.js` : "iPod.js";
 };
 
-export const isDev = () => window.location.origin.includes('localhost:3000');
+export const isDev = () => window.location.origin.includes("localhost:3000");


### PR DESCRIPTION
This pull sets up the ability for the application to determine if it needs to fetch a new access token from the Spotify api. 

It will determine if an access token has ever been generated, and if so, will attempt to use the `refresh_token` to get a new access token if it's been more than 30 minutes.

If no access token has ever been retrieved, we display the "Spotify Signin" view.